### PR TITLE
Add configurable web player

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@
 Exe files are officially removed due to lot of issue( will be back once I manage to fix them)
 Also now you can run fixer.bat(one time) if other 3 bat files give you error.
 
-Note 
+Note
 - Always keep fixer.bat,adb.exe and AdbWinApi.dll in same folder.
 - Other 3 bat files can run from any location.
-    
+
 
 #Updated files
 **Now you dont need to donwload platform-tools**
@@ -31,3 +31,6 @@ Open any file using pushtoWSA.bat(right click open with) to transfer to WSA down
 
 Open WSAsettings.bat file to open WSA settings.
 
+## Web Player (Beta)
+
+A simple HTML5 player is available in the `web/` directory for watching tutorial videos without the "No playable sources found" error shown by older embeds. The player reads its configuration from `web/player-config.json` and automatically selects the first playable source, falling back to HLS.js when the browser does not support HLS natively. Update the configuration file with your own MP4, HLS (`.m3u8`) or DASH (`.mpd`) sources as required, then host the `web` folder on any static server.

--- a/web/index.html
+++ b/web/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>EasySideload Web Player</title>
+    <link rel="stylesheet" href="./player.css" />
+  </head>
+  <body>
+    <main class="player-shell">
+      <header class="player-header">
+        <h1>EasySideload Web Player</h1>
+        <p class="player-subtitle">
+          This lightweight player automatically picks a playable source and falls back
+          to HLS.js when your browser does not support HLS streams natively.
+        </p>
+      </header>
+
+      <section class="player-wrapper" aria-live="polite">
+        <div class="player-aspect">
+          <video
+            id="web-player"
+            class="player"
+            controls
+            preload="metadata"
+            playsinline
+            poster=""
+          ></video>
+          <div id="player-message" class="player-message" hidden></div>
+        </div>
+        <div class="player-controls">
+          <label class="control-label" for="source-selector">Quality</label>
+          <select id="source-selector" class="source-selector" data-role="source-selector"></select>
+        </div>
+      </section>
+
+      <footer class="player-footer">
+        <p>
+          Update <code>web/player-config.json</code> with your own media sources. You can
+          link to MP4 files, HLS manifests (<code>.m3u8</code>) or DASH manifests
+          (<code>.mpd</code>), and the player will automatically pick the first playable
+          option.
+        </p>
+      </footer>
+    </main>
+
+    <script src="https://cdn.jsdelivr.net/npm/hls.js@1.5.6/dist/hls.min.js" integrity="sha384-/w+OyADdlqVIGZADa7nmG/pl6gSkdVXNSyy+MyO+Yk5jHxYhPn2TYaZYARt50o5E" crossorigin="anonymous"></script>
+    <script type="module" src="./player.js"></script>
+  </body>
+</html>

--- a/web/player-config.json
+++ b/web/player-config.json
@@ -1,0 +1,17 @@
+{
+  "poster": "https://images.pexels.com/photos/799137/pexels-photo-799137.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=720&w=1280",
+  "sources": [
+    {
+      "label": "Full HD (MP4)",
+      "src": "https://interactive-examples.mdn.mozilla.net/media/cc0-videos/flower.mp4",
+      "type": "video/mp4",
+      "autoplay": false,
+      "poster": "https://images.pexels.com/photos/799137/pexels-photo-799137.jpeg?auto=compress&cs=tinysrgb&dpr=2&h=720&w=1280"
+    },
+    {
+      "label": "Adaptive (HLS)",
+      "src": "https://test-streams.mux.dev/x36xhzz/x36xhzz.m3u8",
+      "type": "application/x-mpegURL"
+    }
+  ]
+}

--- a/web/player.css
+++ b/web/player.css
@@ -1,0 +1,136 @@
+:root {
+  color-scheme: dark light;
+  font-family: "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  line-height: 1.5;
+  --shell-max-width: 960px;
+  --shell-padding: clamp(1rem, 2vw, 2rem);
+  --accent-color: #4e7fff;
+  --border-radius: 18px;
+  --background: #111827;
+  --background-strong: rgba(17, 24, 39, 0.85);
+  --text: #f9fafb;
+  --text-muted: rgba(249, 250, 251, 0.65);
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: radial-gradient(circle at top, #1f2937, #030712 70%);
+  color: var(--text);
+}
+
+.player-shell {
+  width: min(100% - 2 * var(--shell-padding), var(--shell-max-width));
+  margin: var(--shell-padding);
+  background: var(--background-strong);
+  backdrop-filter: blur(14px);
+  border-radius: var(--border-radius);
+  box-shadow: 0 30px 80px rgba(15, 23, 42, 0.5);
+  padding: clamp(1.5rem, 3vw, 3rem);
+  box-sizing: border-box;
+}
+
+.player-header {
+  margin-bottom: clamp(1rem, 2vw, 2rem);
+}
+
+.player-header h1 {
+  margin: 0;
+  font-size: clamp(1.6rem, 2.5vw, 2.2rem);
+}
+
+.player-subtitle {
+  margin-top: 0.5rem;
+  color: var(--text-muted);
+}
+
+.player-wrapper {
+  display: grid;
+  gap: 1rem;
+}
+
+.player-aspect {
+  position: relative;
+  background: #000;
+  border-radius: calc(var(--border-radius) - 4px);
+  overflow: hidden;
+  padding-top: 56.25%;
+}
+
+.player {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  background: #000;
+  border: none;
+  border-radius: inherit;
+}
+
+.player-message {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  padding: 1.5rem;
+  background: rgba(3, 7, 18, 0.85);
+  color: var(--text);
+  font-weight: 600;
+}
+
+.player-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.control-label {
+  font-weight: 600;
+}
+
+.source-selector {
+  flex: 1;
+  background: rgba(59, 130, 246, 0.1);
+  border: 1px solid rgba(59, 130, 246, 0.5);
+  color: var(--text);
+  padding: 0.6rem 0.75rem;
+  border-radius: 999px;
+  font-size: 1rem;
+}
+
+.source-selector:focus {
+  outline: 2px solid var(--accent-color);
+  outline-offset: 2px;
+}
+
+.player-footer {
+  margin-top: clamp(1.5rem, 2vw, 2.5rem);
+  color: var(--text-muted);
+}
+
+code {
+  font-family: "SFMono-Regular", Consolas, "Liberation Mono", Menlo, monospace;
+  background: rgba(255, 255, 255, 0.08);
+  padding: 0.1rem 0.4rem;
+  border-radius: 0.4rem;
+}
+
+@media (max-width: 600px) {
+  .player-shell {
+    padding: clamp(1rem, 4vw, 1.75rem);
+  }
+
+  .player-controls {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .control-label {
+    font-size: 0.9rem;
+  }
+}

--- a/web/player.js
+++ b/web/player.js
@@ -1,0 +1,178 @@
+const video = document.getElementById('web-player');
+const selector = document.querySelector('[data-role="source-selector"]');
+const messageEl = document.getElementById('player-message');
+
+function showMessage(text) {
+  messageEl.textContent = text;
+  messageEl.hidden = false;
+  video.setAttribute('aria-hidden', 'true');
+}
+
+function hideMessage() {
+  messageEl.hidden = true;
+  video.removeAttribute('aria-hidden');
+}
+
+function guessMediaType(source) {
+  if (source.type) {
+    return source.type;
+  }
+
+  const url = source.src || '';
+
+  if (url.includes('.m3u8')) {
+    return 'application/x-mpegURL';
+  }
+
+  if (url.includes('.mpd')) {
+    return 'application/dash+xml';
+  }
+
+  if (url.match(/\.mp4($|\?)/)) {
+    return 'video/mp4';
+  }
+
+  if (url.match(/\.webm($|\?)/)) {
+    return 'video/webm';
+  }
+
+  return '';
+}
+
+function canPlaySource(type) {
+  if (!type) {
+    return false;
+  }
+
+  if (type === 'application/x-mpegURL') {
+    if (video.canPlayType('application/vnd.apple.mpegurl')) {
+      return true;
+    }
+    return Boolean(window.Hls && window.Hls.isSupported());
+  }
+
+  if (type === 'application/dash+xml') {
+    return 'MediaSource' in window;
+  }
+
+  return video.canPlayType(type) !== '';
+}
+
+function configureSelector(sources, active) {
+  selector.innerHTML = '';
+  sources.forEach((source, index) => {
+    const option = document.createElement('option');
+    option.value = index.toString();
+    option.textContent = source.label || source.type || `Source ${index + 1}`;
+    if (source === active) {
+      option.selected = true;
+    }
+    selector.append(option);
+  });
+}
+
+function setVideoSource(source) {
+  const type = guessMediaType(source);
+  if (!canPlaySource(type)) {
+    throw new Error(`Browser cannot play source type: ${type || 'unknown'}`);
+  }
+
+  hideMessage();
+  video.pause();
+
+  if (window.hlsInstance) {
+    window.hlsInstance.destroy();
+    window.hlsInstance = undefined;
+  }
+
+  if (type === 'application/x-mpegURL' && window.Hls && window.Hls.isSupported()) {
+    const hls = new window.Hls();
+    hls.loadSource(source.src);
+    hls.attachMedia(video);
+    window.hlsInstance = hls;
+  } else {
+    video.src = source.src;
+    if (type) {
+      video.type = type;
+    }
+  }
+
+  if (source.poster) {
+    video.poster = source.poster;
+  }
+
+  const autoplay = source.autoplay ?? false;
+  if (autoplay) {
+    video.play().catch(() => {
+      showMessage('Autoplay was blocked by the browser. Press play to start the video.');
+    });
+  }
+}
+
+async function loadConfig() {
+  try {
+    const response = await fetch('./player-config.json', { cache: 'no-store' });
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}`);
+    }
+    return await response.json();
+  } catch (error) {
+    showMessage(`Unable to load player configuration: ${error.message}`);
+    throw error;
+  }
+}
+
+function pickInitialSource(config) {
+  const sources = config.sources || [];
+  if (!sources.length) {
+    showMessage('Player configuration does not define any sources.');
+    return null;
+  }
+
+  const url = new URL(window.location.href);
+  const sourceLabel = url.searchParams.get('quality');
+  const srcUrl = url.searchParams.get('src');
+
+  if (srcUrl) {
+    return { src: srcUrl, label: 'Custom', type: guessMediaType({ src: srcUrl }) };
+  }
+
+  if (sourceLabel) {
+    const matching = sources.find((source) => source.label === sourceLabel);
+    if (matching && canPlaySource(guessMediaType(matching))) {
+      return matching;
+    }
+  }
+
+  return sources.find((source) => canPlaySource(guessMediaType(source)));
+}
+
+async function bootstrap() {
+  const config = await loadConfig();
+  if (!config) {
+    return;
+  }
+
+  const playableSource = pickInitialSource(config);
+
+  if (!playableSource) {
+    showMessage('No playable sources were found. Please update player-config.json.');
+    return;
+  }
+
+  configureSelector(config.sources, playableSource);
+  setVideoSource(playableSource);
+
+  selector.addEventListener('change', (event) => {
+    const index = Number.parseInt(event.target.value, 10);
+    const selectedSource = config.sources[index];
+    try {
+      setVideoSource(selectedSource);
+    } catch (error) {
+      showMessage(error.message);
+      selector.value = config.sources.indexOf(playableSource).toString();
+    }
+  });
+}
+
+bootstrap();


### PR DESCRIPTION
## Summary
- add a standalone HTML5 web player that auto-selects playable media and falls back to HLS.js
- provide styling, configuration, and documentation for the new player to prevent "No playable sources" errors

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68e6208039dc832c861f5d52843bf0c6